### PR TITLE
fix: increase stop timeout for Postgres containers (#350)

### DIFF
--- a/engine/internal/retrieval/engine/postgres/logical/dump.go
+++ b/engine/internal/retrieval/engine/postgres/logical/dump.go
@@ -278,7 +278,7 @@ func (d *DumpJob) Run(ctx context.Context) (err error) {
 		return errors.Wrapf(err, "failed to create container %q", d.dumpContainerName())
 	}
 
-	defer tools.RemoveContainer(ctx, d.dockerClient, dumpCont.ID, cont.StopTimeout)
+	defer tools.RemoveContainer(ctx, d.dockerClient, dumpCont.ID, tools.DefaultStopTimeout)
 
 	defer func() {
 		if err != nil {
@@ -491,7 +491,7 @@ func setupPGData(ctx context.Context, dockerClient *client.Client, dataDir strin
 func updateConfigs(ctx context.Context, dockerClient *client.Client, dataDir, contID string, configs map[string]string) error {
 	log.Dbg("Stopping container to update configuration")
 
-	tools.StopContainer(ctx, dockerClient, contID, cont.StopTimeout)
+	tools.StopContainer(ctx, dockerClient, contID, tools.DefaultStopTimeout)
 
 	// Run basic PostgreSQL configuration.
 	cfgManager, err := pgconfig.NewCorrector(dataDir)

--- a/engine/internal/retrieval/engine/postgres/logical/restore.go
+++ b/engine/internal/retrieval/engine/postgres/logical/restore.go
@@ -206,7 +206,7 @@ func (r *RestoreJob) Run(ctx context.Context) (err error) {
 		return errors.Wrapf(err, "failed to create container %q", r.restoreContainerName())
 	}
 
-	defer tools.RemoveContainer(ctx, r.dockerClient, restoreCont.ID, cont.StopTimeout)
+	defer tools.RemoveContainer(ctx, r.dockerClient, restoreCont.ID, tools.DefaultStopTimeout)
 
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
Issue: https://gitlab.com/postgres-ai/database-lab/-/issues/350

Increase the stop timeout for Postgres containers from 30s to 600s to avoid interrupting the shutdown of the database system.